### PR TITLE
fix object not found warning in "%<a-%"

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # pryr 0.1.1.9000
 
+* Fixed a warning in `%<a-%` when reassigning an active binding (#39).
+
 # pryr 0.1.1
 
 * `address()` no longer changes `NAMED()` status of x (#24).

--- a/R/assign-active.r
+++ b/R/assign-active.r
@@ -29,7 +29,7 @@
 
   # Mimic regular assignment operation which overrides existing bindings
   if (exists(deparse(x), envir = env, inherits = FALSE)) {
-    rm(x, envir = env)
+    rm(list = deparse(x), envir = env)
   }
 
   makeActiveBinding(deparse(x), f, env)


### PR DESCRIPTION
The `%<a-%` produces an `object 'x' not found` warning when trying to overwrite an existing active binding, for example:

```R
library("pryr")
a <- 1
b %<a-% (a+1)
a
# [1] 1
b
# [1] 2
b %<a-% (a+2)
# Warning message:
# In rm(x, envir = env) : object 'x' not found
a
# [1] 1
b
# [1] 3
```

Switching to the `list` argument in `rm` solves the problem.