### PR TITLE
Use deparse() rather than capturing the output for primitive_name

### DIFF
--- a/R/ftype.r
+++ b/R/ftype.r
@@ -45,8 +45,8 @@ ftype <- function(f) {
 # Hacky method to get name of primitive function
 primitive_name <- function(f) {
   stopifnot(is.primitive(f))
-  
-  str <- capture.output(print(f))
+
+  str <- deparse(f)
   match <- regexec(".Primitive\\([\"](.*?)[\"]\\)", str)
   regmatches(str, match)[[1]][2]
 }

--- a/tests/testthat/test-ftype.r
+++ b/tests/testthat/test-ftype.r
@@ -21,3 +21,11 @@ test_that("RC methods return as expected", {
 
   expect_equal(ftype(b$f), c("rc", "method"))
 })
+
+test_that("primitive_name return as expected", {
+
+  expect_equal(primitive_name(`@`), "@")
+
+  at <- `@`
+  expect_equal(primitive_name(at), "@")
+})


### PR DESCRIPTION
Makes this less hacky :smile:. Plus this way it will still work if someone overloads the print method for primitives. I added a simple test as well since there wasn't one previously.