### PR TITLE
Update mem.R to reference generic memory units

### DIFF
--- a/R/mem.R
+++ b/R/mem.R
@@ -5,10 +5,10 @@
 #' nor the "gc trigger" and "max used" columns are typically important. What
 #' we're usually most interested in is the the first column: the total memory
 #' used. This function wraps around \code{gc()} to return the total amount of
-#' memory (in megabytes) currently used by R.
+#' memory (with units) currently used by R.
 #'
 #' @export
-#' @return Megabytes of ram used by R objects.
+#' @return RAM (with units) used by R objects.
 #' @examples
 #' mem_used()
 mem_used <- function() {


### PR DESCRIPTION
Nothing in this file specifically returns megabytes. If the sum() function in line 15 returns a value >= 1000000000, then the show_bytes() function returns units of "GB" or greater. Similarly, show_bytes(999999) == 1,000 kB.

Another possible change would be to force megabytes as the unit returned.