### PR TITLE
Update names_c.R

### DIFF
--- a/R/names_c.R
+++ b/R/names_c.R
@@ -74,7 +74,7 @@ show_c_source  <- function(fun) {
 #' @export
 names_c <- function() {
   if (exists("names_c", envir = cache)) return(cache$names_c)
-  lines <- readLines("http://svn.r-project.org/R/trunk/src/main/names.c")
+  lines <- readLines("https://svn.r-project.org/R/trunk/src/main/names.c")
 
   # Find lines starting with {"
   fun_table <- lines[grepl("^[{][\"]", lines)]


### PR DESCRIPTION
Replace "http://svn.r-project.org/R/trunk/src/main/names.c" by "https://svn.r-project.org/R/trunk/src/main/names.c" — I don’t fully understand why, but pryr::names_c() raises `Error in file(con, "r") : cannot open the connection` with the http address. With https it seems to work fine.