### PR TITLE
Use HTTPS for SVN lookup.

### DIFF
--- a/R/names_c.R
+++ b/R/names_c.R
@@ -74,7 +74,7 @@ show_c_source  <- function(fun) {
 #' @export
 names_c <- function() {
   if (exists("names_c", envir = cache)) return(cache$names_c)
-  lines <- readLines("http://svn.r-project.org/R/trunk/src/main/names.c")
+  lines <- readLines("https://svn.r-project.org/R/trunk/src/main/names.c")
 
   # Find lines starting with {"
   fun_table <- lines[grepl("^[{][\"]", lines)]


### PR DESCRIPTION
Closes #48 (hopefully). `pryr` is somewhat broken for me without this. 
Lots of newer NOTEs in devtools::check(), mainly `no visible global function`, but also some `used in a situation where it does not exist` which may warrant attention.
Tests all pass.