### PR TITLE
Suppress warning from g++

### DIFF
--- a/src/promise.cpp
+++ b/src/promise.cpp
@@ -68,7 +68,7 @@ std::vector<RObject> explicitDots(Environment env) {
 
   dots = env.find("...");
 
-  SEXP el;
+  SEXP el = R_NilValue;
   for(SEXP nxt = dots; nxt != R_NilValue; el = CAR(nxt), nxt = CDR(nxt)) {
     out.push_back(makeExplicit(el));
 


### PR DESCRIPTION
I got 

```sh
ccache g++ -I/usr/share/R/include -DNDEBUG  -I"/usr/local/lib/R/site-library/Rcpp/include"    -fpic  -g -O3 -Wall -pipe   -march=native -c promise.cpp -o promise.o
promise.cpp: In function ‘std::vector<Rcpp::RObject_Impl<Rcpp::PreserveStorage> > explicitDots(Rcpp::Environment)’:
promise.cpp:73:31: warning: ‘el’ may be used uninitialized in this function [-Wmaybe-uninitialized]
     out.push_back(makeExplicit(el));
                   ~~~~~~~~~~~~^~~~
```

with g++-7.2, and the suggested change makes the warning go away:

ccache g++ -I/usr/share/R/include -DNDEBUG  -I"/usr/local/lib/R/site-library/Rcpp/include"    -fpic  -g -O3 -Wall -pipe   -march=native -c object_size.cpp -o object_size.o
ccache g++ -I/usr/share/R/include -DNDEBUG  -I"/usr/local/lib/R/site-library/Rcpp/include"    -fpic  -g -O3 -Wall -pipe   -march=native -c promise.cpp -o promise.o
ccache gcc -I/usr/share/R/include -DNDEBUG  -I"/usr/local/lib/R/site-library/Rcpp/include"    -fpic  -g -O3 -Wall -pipe   -std=gnu99 -march=native -c size-info.c -o size-info.o
ccache g++ -I/usr/share/R/include -DNDEBUG  -I"/usr/local/lib/R/site-library/Rcpp/include"    -fpic  -g -O3 -Wall -pipe   -march=native -c slice.cpp -o slice.o
```