### PR TITLE
Add `bytes()` support for symbols and internal strings

### DIFF
--- a/tests/testthat/test-bytes.r
+++ b/tests/testthat/test-bytes.r
@@ -62,3 +62,8 @@ test_that("we read character strings in the right order", {
 
 
 })
+
+test_that("bytes and bits of symbols", {
+  expect_equal(bits(as.name("foo")), bits("foo"))
+  expect_equal(bytes(as.name("foo")), bytes("foo"))
+})


### PR DESCRIPTION
Useful for debugging encoding issues.
Adding this here since we don't have `bytes()` in lobstr yet.

cc @hadley.